### PR TITLE
Update gaea port

### DIFF
--- a/configuration/scripts/cice.batch.csh
+++ b/configuration/scripts/cice.batch.csh
@@ -371,7 +371,7 @@ cat >> ${jobfile} << EOFB
 #SBATCH -J ${ICE_CASENAME}
 #SBATCH --partition=batch
 #SBATCH --qos=${queue}
-#SBATCH --account=nggps_emc
+#SBATCH --account=${acct}
 #SBATCH --clusters=c5
 #SBATCH --time=${batchtime}
 #SBATCH --nodes=${nnodes}
@@ -388,7 +388,7 @@ cat >> ${jobfile} << EOFB
 #SBATCH -J ${ICE_CASENAME}
 #SBATCH --partition=batch
 #SBATCH --qos=${queue}
-#SBATCH --account=sfs-emc
+#SBATCH --account=${acct}
 #SBATCH --clusters=c6
 #SBATCH --time=${batchtime}
 #SBATCH --nodes=${nnodes}

--- a/configuration/scripts/machines/Macros.gaeac5_intel
+++ b/configuration/scripts/machines/Macros.gaeac5_intel
@@ -4,11 +4,11 @@
 
 CPP        := fpp
 CPPDEFS    := -DFORTRANUNDERSCORE ${ICE_CPPDEFS}
-CFLAGS     := -c -O2 -fp-model precise   -xHost
+CFLAGS     := -c -O2 -fp-model precise -march=core-avx2
 
 FIXEDFLAGS := -132
 FREEFLAGS  := -FR
-FFLAGS     := -fp-model precise -convert big_endian -assume byterecl -ftz -traceback -align array64byte  -march=core-avx2
+FFLAGS     := -fp-model precise -convert big_endian -assume byterecl -ftz -traceback -align array64byte -march=core-avx2
 FFLAGS_NOOPT:= -O0
 
 ifeq ($(ICE_BLDDEBUG), true)

--- a/configuration/scripts/machines/Macros.gaeac6_intel
+++ b/configuration/scripts/machines/Macros.gaeac6_intel
@@ -4,11 +4,11 @@
 
 CPP        := fpp
 CPPDEFS    := -DFORTRANUNDERSCORE ${ICE_CPPDEFS}
-CFLAGS     := -c -O2 -fp-model precise   -xHost
+CFLAGS     := -c -O2 -fp-model precise -march=core-avx2
 
 FIXEDFLAGS := -132
 FREEFLAGS  := -FR
-FFLAGS     := -fp-model precise -convert big_endian -assume byterecl -ftz -traceback -align array64byte  -march=core-avx2
+FFLAGS     := -fp-model precise -convert big_endian -assume byterecl -ftz -traceback -align array64byte -march=core-avx2
 FFLAGS_NOOPT:= -O0
 
 ifeq ($(ICE_BLDDEBUG), true)

--- a/configuration/scripts/machines/env.gaeac5_intel
+++ b/configuration/scripts/machines/env.gaeac5_intel
@@ -22,7 +22,7 @@ setenv OMP_STACKSIZE 64M
 
 endif
 
-env | grep NETCDF
+#env | grep NETCDF
 
 setenv ICE_MACHINE_MACHNAME gaea
 setenv ICE_MACHINE_MACHINFO "HPE-EX Cray X3000, AMD EPYC 7H12 2.6 GHz, HPE Slingshot interconnect"

--- a/configuration/scripts/machines/env.gaeac5_intel
+++ b/configuration/scripts/machines/env.gaeac5_intel
@@ -10,7 +10,7 @@ if ("$inp" != "-nomodules") then
 source $MODULESHOME/init/csh
 module load PrgEnv-intel/8.6.0
 module load intel/2025.0
-module load cray-mpich 8.1.32
+module load cray-mpich/8.1.32
 module load cray-hdf5/1.14.3.1
 module load cray-netcdf/4.9.0.13
 setenv NETCDF $NETCDF_DIR
@@ -30,7 +30,7 @@ setenv ICE_MACHINE_ENVNAME intel
 setenv ICE_MACHINE_ENVINFO "ifort 2025.0, cray-mpich 8.1.32, cray-netcdf 4.9.0.13"
 setenv ICE_MACHINE_MAKE gmake
 setenv ICE_MACHINE_WKDIR $HOME/scratch/CICE_RUNS
-setenv ICE_MACHINE_INPUTDATA /ncrc/home1/Robert.Grumbine/rgdev/CICE_INPUTDATA
+setenv ICE_MACHINE_INPUTDATA /ncrc/home1/Anthony.Craig/scratch
 setenv ICE_MACHINE_BASELINE $HOME/scratch/CICE_BASELINE
 setenv ICE_MACHINE_SUBMIT "sbatch"
 setenv ICE_MACHINE_TPNODE 128

--- a/configuration/scripts/machines/env.gaeac6_intel
+++ b/configuration/scripts/machines/env.gaeac6_intel
@@ -33,7 +33,7 @@ setenv ICE_MACHINE_ENVNAME intel
 setenv ICE_MACHINE_ENVINFO "intel 2025.0, cray-mpich 8.1.32, cray-netcdf 4.9.0.13"
 setenv ICE_MACHINE_MAKE gmake
 setenv ICE_MACHINE_WKDIR $HOME/scratch6/CICE_RUNS
-setenv ICE_MACHINE_INPUTDATA /ncrc/home1/Robert.Grumbine/scratch6/CICE_INPUTDATA
+setenv ICE_MACHINE_INPUTDATA /ncrc/home1/Anthony.Craig/scratch6
 setenv ICE_MACHINE_BASELINE $HOME/scratch6/CICE_BASELINE
 setenv ICE_MACHINE_SUBMIT "sbatch"
 setenv ICE_MACHINE_TPNODE 192

--- a/configuration/scripts/machines/env.gaeac6_intel
+++ b/configuration/scripts/machines/env.gaeac6_intel
@@ -16,8 +16,8 @@ module load cray-mpich/8.1.32
 module load cray-hdf5/1.14.3.1
 module load cray-netcdf/4.9.0.13
 setenv NETCDF $NETCDF_DIR
-echo zzz   final module list
-module list
+#echo zzz   final module list
+#module list
 #module avail intel
 
 # May be needed for OpenMP memory
@@ -25,7 +25,7 @@ setenv OMP_STACKSIZE 64M
 
 endif
 
-env | grep NETCDF
+#env | grep NETCDF
 
 setenv ICE_MACHINE_MACHNAME gaea
 setenv ICE_MACHINE_MACHINFO "HPE-EX Cray3000, AMD EPYC 9654 2.4GHz, HPE Slingshot interconnect"
@@ -38,6 +38,6 @@ setenv ICE_MACHINE_BASELINE $HOME/scratch6/CICE_BASELINE
 setenv ICE_MACHINE_SUBMIT "sbatch"
 setenv ICE_MACHINE_TPNODE 192
 setenv ICE_MACHINE_ACCT A00000
-setenv ICE_MACHINE_QUEUE "windfall"
+setenv ICE_MACHINE_QUEUE "normal"
 setenv ICE_MACHINE_BLDTHRDS 1
 setenv ICE_MACHINE_QSTAT "squeue --jobs="


### PR DESCRIPTION

Recommend the following changes.

- cice.batch.csh should not have hard-wired account.  These are normally set by the env file, .cice_proj, or --acct on the cice.setup command line.
- remove -xHost from CFLAGS, add -march=core-avx2
- comment out debug output from env files
- change the default queue from windfall to normal for gaeac6.
  - normal is going to be what we want in the long term
  - windfall is almost unusable now as jobs wait for a long while in the queue and you can only have 2 jobs queued at a time
  - users can specify "cice.setup --queue windfall" in the short term as needed

I have tested these on gaea.  gaeac5 works fine, I have nggps_emc set in my .cice_proj file.  I have confirmed gaeac6 builds and submits fine with "cice.setup --acct sfs_emc --queue windfall".  I have two test jobs waiting in the queue.